### PR TITLE
path fixes to account for spaces under Unix

### DIFF
--- a/src/app/autocompiler/main.cpp
+++ b/src/app/autocompiler/main.cpp
@@ -22,7 +22,7 @@ struct compiler
 #		if defined(IS_WINDOWS)
 			sprintf( command_line, "\"\"%s.exe\" \"%s\" \"%s\"\"", path.c_str(), asset_path, output_folder );
 #		else
-			sprintf( command_line, "%s \"%s\" \"%s\"", path.c_str(), asset_path, output_folder );
+			sprintf( command_line, "\"%s\" \"%s\" \"%s\"", path.c_str(), asset_path, output_folder );
 #		endif
         if(!run( command_line, false, "Compiling %s.", asset_path ))
 		{

--- a/src/app/png/main.cpp
+++ b/src/app/png/main.cpp
@@ -107,7 +107,11 @@ int main( int argument_count, char** arguments )
     }
 	*/
 
+#if defined(IS_WINDOWS)
     sprintf( command_line, "\"\"%s\" \"%s\" \"%s\"\"", get_python(), build_tool_path.c_str(), input_file_path.c_str());
+#else
+	sprintf( command_line, "\"%s\" \"%s\" \"%s\"", get_python(), build_tool_path.c_str(), input_file_path.c_str());
+#endif
     
     run( command_line, true, "Compiling '%s'", input_file_path.c_str() );
 

--- a/src/app/scml/main.cpp
+++ b/src/app/scml/main.cpp
@@ -2604,7 +2604,11 @@ int main( int argument_count, char** arguments )
 
 	char command_line[32768];
 	sprintf(command_line,
+#if defined(IS_WINDOWS)
 			"\"\"%s\" \"%s\" \"%s\" \"%s\"\"",
+#else
+			"\"%s\" \"%s\" \"%s\" \"%s\"",
+#endif
 			get_python(),
 			(app_folder/"compiler_scripts"/"zipanim.py").c_str(),
 			get_asset_temp_dir(),
@@ -2613,7 +2617,11 @@ int main( int argument_count, char** arguments )
 	run( command_line, true, "Packaging '%s'", output_package_file_path.basename().c_str() );
 
 	sprintf(command_line,
+#if defined(IS_WINDOWS)
 			"\"\"%s\" \"%s\" --skip_update_prefabs --outputdir \"%s\" --prefabsdir \"%s\" \"%s\"\"",
+#else
+			"\"%s\" \"%s\" --skip_update_prefabs --outputdir \"%s\" --prefabsdir \"%s\" \"%s\"",
+#endif
 			get_python(),
 			(app_folder/"exported"/"export.py").c_str(),
 			output_dir.c_str(),


### PR DESCRIPTION
Fixed to match, under Linux and Mac, the fix applied for paths with spaces in the Windows case.
