### PR TITLE
Fixes macOS build

### DIFF
--- a/src/premake4.lua
+++ b/src/premake4.lua
@@ -47,7 +47,7 @@ local function deduceOS()
 		if kernel_name == "linux" then
 			return "linux"
 		elseif kernel_name == "darwin" then
-			return "osx"
+			return "macosx"
 		end
 	end
 end
@@ -120,7 +120,7 @@ local definesMacros = (function()
 end)()
 
 local function targetIsUnix()
-	return _OPTIONS.os == "linux" or _OPTIONS.os == "osx"
+	return _OPTIONS.os == "linux" or _OPTIONS.os == "macosx"
 end
 
 local function targetIsWindows()

--- a/src/premake4.lua
+++ b/src/premake4.lua
@@ -244,7 +244,7 @@ local copyDirTree = (function()
 	local cmd_template
 
 	if hostIsUnix() then
-		cmd_template = "cp -rT %q %q"
+		cmd_template = "cp -r %q %q"
 	else
 		cmd_template = 'xcopy /e /y "%s" "%s"'
 	end


### PR DESCRIPTION
The `premake.sh` build was failing on macOS. It was caused by inconsistent key naming on one table of the `src/premak4.lua` file:

```
$ ./premake.sh
Target OS not specified. Assuming it's the host OS.
...Don't Starve Mod Tools/ds_mod_tools/src/premake4.lua:64: Unsupported os!

```

After fixing the key names, the build on macOS succeeds:

```
$ ./premake.sh
Target OS not specified. Assuming it's the host OS.
which "unzip" &>/dev/null
mkdir -p "../build"
mkdir -p "../build/dont_starve/mods"
unzip -q -o "../pkg/tst/wand.zip" -d "../build/dont_starve/mods"
mkdir -p "../build/osx/mod_tools"
cp -rT "../pkg/cmn/mod_tools" "../build/osx/mod_tools"
mkdir -p "../build/osx/mod_tools/buildtools/osx/Python27"
cp -rT "../pkg/unix/Python27" "../build/osx/mod_tools/buildtools/osx/Python27"
mkdir -p "../build/osx/mod_tools"
cp -rT "../pkg/unix/mod_tools" "../build/osx/mod_tools"
Building configurations...
Running action 'gmake'...
Generating ../build/proj/Makefile...
Generating ../build/proj/scml.make...
Generating ../build/proj/png.make...
Generating ../build/proj/autocompiler.make...
Generating ../build/proj/modtoollib.make...
Done.

```