### PR TITLE
Fix premake copying directory tree on Unix

### DIFF
--- a/src/premake4.lua
+++ b/src/premake4.lua
@@ -244,7 +244,7 @@ local copyDirTree = (function()
 	local cmd_template
 
 	if hostIsUnix() then
-		cmd_template = "cp -r %q %q"
+		cmd_template = 'cp -r "%s" "%s/.."'
 	else
 		cmd_template = 'xcopy /e /y "%s" "%s"'
 	end


### PR DESCRIPTION
Just a quick fix. `cp` default behaviour differs from `xcopy` when it comes to copying directory trees, as it only requires the destination directory without the directory name itself.

### Outputs

<details>
<summary><b>Directory tree (before)</b></summary>

```txt
build
├── dont_starve
│   └── mods
│       └── wand
│           ├── exported
│           │   └── wand
│           └── images
│               └── inventoryimages
├── linux
│   └── mod_tools
│       ├── buildtools
│       │   └── linux
│       │       └── Python27
│       │           └── Python27
│       │               └── Lib
│       │                   └── site-packages
│       │                       └── klei
│       └── mod_tools
│           ├── compiler_scripts
│           ├── data
│           ├── exported
│           ├── scripts
│           └── tools
│               └── scripts
└── proj
```
</details>

<details>
<summary><b>Directory tree (after)</b></summary>

```txt
build
├── dont_starve
│   └── mods
│       └── wand
│           ├── exported
│           │   └── wand
│           └── images
│               └── inventoryimages
├── linux
│   └── mod_tools
│       ├── buildtools
│       │   └── linux
│       │       └── Python27
│       │           └── Lib
│       │               └── site-packages
│       │                   └── klei
│       ├── compiler_scripts
│       ├── data
│       ├── exported
│       ├── scripts
│       └── tools
│           └── scripts
└── proj
```
</details>

<details>
<summary><b>Premake output (before)</b></summary>

```txt
Target OS not specified. Assuming it's the host OS.
which "unzip" &>/dev/null
mkdir -p "../build"
/usr/bin/unzip
mkdir -p "../build/dont_starve/mods"
unzip -q -o "../pkg/tst/wand.zip" -d "../build/dont_starve/mods"
mkdir -p "../build/linux/mod_tools"
cp -r "../pkg/cmn/mod_tools" "../build/linux/mod_tools"
mkdir -p "../build/linux/mod_tools/buildtools/linux/Python27"
cp -r "../pkg/unix/Python27" "../build/linux/mod_tools/buildtools/linux/Python27"
mkdir -p "../build/linux/mod_tools"
cp -r "../pkg/unix/mod_tools" "../build/linux/mod_tools"
Building configurations...
Running action 'gmake'...
Generating ../build/proj/Makefile...
Generating ../build/proj/scml.make...
Generating ../build/proj/png.make...
Generating ../build/proj/autocompiler.make...
Generating ../build/proj/modtoollib.make...
Done.
```
</details>

<details>
<summary><b>Premake output (after)</b></summary>

```txt
Target OS not specified. Assuming it's the host OS.
which "unzip" &>/dev/null
mkdir -p "../build"
/usr/bin/unzip
mkdir -p "../build/dont_starve/mods"
unzip -q -o "../pkg/tst/wand.zip" -d "../build/dont_starve/mods"
mkdir -p "../build/linux/mod_tools"
cp -r "../pkg/cmn/mod_tools" "../build/linux/mod_tools/.."
mkdir -p "../build/linux/mod_tools/buildtools/linux/Python27"
cp -r "../pkg/unix/Python27" "../build/linux/mod_tools/buildtools/linux/Python27/.."
mkdir -p "../build/linux/mod_tools"
cp -r "../pkg/unix/mod_tools" "../build/linux/mod_tools/.."
Building configurations...
Running action 'gmake'...
Generating ../build/proj/Makefile...
Generating ../build/proj/scml.make...
Generating ../build/proj/png.make...
Generating ../build/proj/autocompiler.make...
Generating ../build/proj/modtoollib.make...
Done.
```
</details>

### Tested on

- Linux (Ubuntu 20.04.3 LTS x86_64)
- macOS (macOS 11.5.2 20G95 x86_64)
- Windows (Windows 11 Pro 21H2 22000.176)