### PR TITLE
Fix RGB only images crash issue

### DIFF
--- a/pkg/unix/mod_tools/tools/scripts/optimizeimage.py
+++ b/pkg/unix/mod_tools/tools/scripts/optimizeimage.py
@@ -27,7 +27,7 @@ def Analyze(im, bbox):
 	numblank = 0
 	numopaque = 0
 
-	pixels = im.load()
+	pixels = im.load() if im.mode == "RGBA" else im.convert("RGBA").load()
 	for y in range(bbox.y, bbox.y + bbox.h):
 		for x in range(bbox.x, bbox.x + bbox.w):
 			p = pixels[x,y]

--- a/pkg/win32/mod_tools/tools/scripts/optimizeimage.py
+++ b/pkg/win32/mod_tools/tools/scripts/optimizeimage.py
@@ -27,7 +27,7 @@ def Analyze(im, bbox):
 	numblank = 0
 	numopaque = 0
 
-	pixels = im.load()
+	pixels = im.load() if im.mode == "RGBA" else im.convert("RGBA").load()
 	for y in range(bbox.y, bbox.y + bbox.h):
 		for x in range(bbox.x, bbox.x + bbox.w):
 			p = pixels[x,y]


### PR DESCRIPTION
For `ExportBuild` -> `optimizeimage.GetImageRegions` -> `QuadTreeNode` -> `Analyze(im, bbox)`:

Replace `pixels = im.load()` with
`pixels = im.load() if im.mode == "RGBA" else im.convert("RGBA").load()`